### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lignum-vitae/goombay/security/code-scanning/2](https://github.com/lignum-vitae/goombay/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily reads repository contents and does not perform any write operations. Therefore, we will set `contents: read` as the permission. This change ensures that the workflow operates with the least privilege necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
