### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lignum-vitae/goombay/security/code-scanning/1](https://github.com/lignum-vitae/goombay/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since this is a linting job that does not require write access, the permissions can be limited to `contents: read`. This ensures that the workflow has only the minimal access required to perform its tasks.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
